### PR TITLE
Add more languages to the playground examples

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -95,7 +95,8 @@
         "curl", 
         "python",
         "go",
-        "java"
+        "java",
+        "ruby"
       ]
     }
   }

--- a/docs.json
+++ b/docs.json
@@ -90,7 +90,13 @@
       "display": "interactive"
     },
     "examples": {
-      "languages": ["javascript", "curl", "python"]
+      "languages": [
+        "javascript",
+        "curl", 
+        "python",
+        "go",
+        "java"
+      ]
     }
   }
 }


### PR DESCRIPTION
adding go, java and ruby. 
this only works in prod, after merged 🤷 