### PR TITLE
Adjust explanation when user loses EOA

### DIFF
--- a/account/accounts.mdx
+++ b/account/accounts.mdx
@@ -89,5 +89,5 @@ If you’ve forgotten the password to your EOA Wallet, you can regain access usi
 However, if you’ve lost access to the seed phrase and cannot regain access to the EOA, you will also lose access to the Safe if it’s the only owner.
 </Warning>
 
-**To mitigate this risk, consider adding multiple owners to your [Safe](https://safe.global/).**
+**To mitigate this risk, consider using a [Safe](https://safe.global/) with multiple owners instead of an EOA.**
 


### PR DESCRIPTION
When a user loses access to an EOA, it was suggested to add multiple owners to the Safe. However, this can be confusing to the users as the Gnosis Pay Safe cannot have multiple owners.

Instead, we should recommend a setup where Safe with multiple owners is the owner of the Gnosis Pay Safe. This is currently not supported by our WebApp, but it is supported by many partners.

Therefore, this is just a simple adjustment to the given recommendation (as a more in-depth one would require mentioning a non-EOA setup).